### PR TITLE
Checksum mechanism with CRC32 algorithm

### DIFF
--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
@@ -170,13 +170,23 @@ public class Database implements Closeable {
      * Calculate script checksum and compare it to committed checksum
      * @param migration
      */
-    public boolean validateChecksum(DbMigration migration) {
+    public String validateChecksum(DbMigration migration) {
         notNull(migration, "migration");
         LOGGER.debug(format("About to validate migration %s checksum", migration.getScriptName()));
         
         String submittedChecksum = getScriptChecksum(migration.getVersion());
+        //check if the migration version exist
+        if (submittedChecksum == null) {
+        	return String.format("Script version %d not found", migration.getVersion());
+        }
+        
         String currentChecksum= ChecksumUtil.encryptSHA512(migration.getMigrationScript());
-        return submittedChecksum.equals(currentChecksum);
+        if (!submittedChecksum.equals(currentChecksum)) {
+        	return String.format("Checksum validation error: %s vs %s", submittedChecksum, currentChecksum);
+        }
+        
+        //validation succeeded
+        return null;
     }
     
     /**

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
@@ -12,6 +12,7 @@ import static org.cognitor.cassandra.migration.util.Ensure.notNullOrEmpty;
 class DbMigration {
     private final String migrationScript;
     private final String scriptName;
+    private final String checksum;
     private final int version;
 
     /**
@@ -21,9 +22,10 @@ class DbMigration {
      * @param version         the schema version this migration will result to.
      * @param migrationScript the migration steps in cql. Must not be null.
      */
-    public DbMigration(String scriptName, int version, String migrationScript) {
+    public DbMigration(String scriptName, int version, String migrationScript, String checksum) {
         this.migrationScript = notNull(migrationScript, "migrationScript");
         this.scriptName = notNullOrEmpty(scriptName, "scriptName");
+        this.checksum = checksum;
         this.version = version;
     }
 
@@ -35,6 +37,10 @@ class DbMigration {
         return scriptName;
     }
 
+    public String getChecksum() {
+        return checksum;
+    }
+    
     public int getVersion() {
         return version;
     }

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
@@ -12,7 +12,7 @@ import static org.cognitor.cassandra.migration.util.Ensure.notNullOrEmpty;
 class DbMigration {
     private final String migrationScript;
     private final String scriptName;
-    private final String checksum;
+    private final int checksum;
     private final int version;
 
     /**
@@ -20,9 +20,10 @@ class DbMigration {
      *
      * @param scriptName      the name of the script without the version part. Must not be null.
      * @param version         the schema version this migration will result to.
+     * @param checksum        the script checksum value	
      * @param migrationScript the migration steps in cql. Must not be null.
      */
-    public DbMigration(String scriptName, int version, String migrationScript, String checksum) {
+    public DbMigration(String scriptName, int version, String migrationScript, int checksum) {
         this.migrationScript = notNull(migrationScript, "migrationScript");
         this.scriptName = notNullOrEmpty(scriptName, "scriptName");
         this.checksum = checksum;
@@ -37,7 +38,7 @@ class DbMigration {
         return scriptName;
     }
 
-    public String getChecksum() {
+    public int getChecksum() {
         return checksum;
     }
     

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationRepository.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationRepository.java
@@ -236,18 +236,11 @@ public class MigrationRepository {
     public List<DbMigration> getMigrationsSinceVersion(int version) {
         List<DbMigration> dbMigrations = new ArrayList<>();
         migrationScripts.stream().filter(script -> script.getVersion() > version).forEach(script -> {
-            dbMigrations.add(createDbMigration(script));
+        	String content = loadScriptContent(script);
+            int checksum= ChecksumUtil.calculateCRC32(content);
+            dbMigrations.add(new DbMigration(script.getScriptName(), script.getVersion(), content, checksum));
         });
         return dbMigrations;
-    }
-
-    private DbMigration createDbMigration(ScriptFile script) {
-        String content = loadScriptContent(script);
-        String checksum= ChecksumUtil.encryptSHA512(content);
-        if (checksum == null) {
-            throw new MigrationException(String.format("Checksum of script %s is null", script.getScriptName()), script.getScriptName());
-        }
-        return new DbMigration(script.getScriptName(), script.getVersion(), content, checksum);
     }
     
     private String loadScriptContent(ScriptFile script) {

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
@@ -64,10 +64,10 @@ public class MigrationTask {
         int databaseVersion = database.getVersion();
         for (DbMigration dbMigration : migrations) {
             if (dbMigration.getVersion() <= databaseVersion) {
-                // check validation
-                boolean checksumResult = database.validateChecksum(dbMigration);
-                if (!checksumResult) {
-                    LOGGER.error(format("Validate script %d checksum failed", database.getVersion()));
+            	// check validation
+                String errorMessage = database.validateChecksum(dbMigration);
+                if (errorMessage != null) {
+                    LOGGER.error(String.format("Script %d validation failed: ", dbMigration.getVersion(), errorMessage));
                     return -1;
                 }
             } else {
@@ -75,6 +75,10 @@ public class MigrationTask {
                 database.execute(dbMigration);
                 migratedScripts++;
             }
+        }
+        
+        if (this.checksumValidation) {
+        	LOGGER.info(format("Keyspace %s validation ended successfully", database.getKeyspaceName(), database.getVersion()));
         }
         
         LOGGER.info(format("Migrated keyspace %s to version %d", database.getKeyspaceName(), database.getVersion()));

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
@@ -50,9 +50,11 @@ public class MigrationTask {
     /**
      * Start the actual migration. Take the version of the database, get all required migrations and execute them or do
      * nothing if the DB is already up to date.
+     * If checksumValidation flag is true, get all existing migration and compare their checksum.
      *
      * At the end the underlying database instance is closed.
      *
+     * @return The number of migrated scripts. for any error, -1 is returned.
      * @throws MigrationException if a migration fails
      */
     public int migrate() {

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/util/ChecksumUtil.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/util/ChecksumUtil.java
@@ -1,0 +1,24 @@
+package org.cognitor.cassandra.migration.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class ChecksumUtil {
+
+	public static String encryptSHA512(String script){
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-512");
+			byte[] bytes = md.digest(script.getBytes());
+			StringBuilder sb = new StringBuilder();
+			for(int i=0; i< bytes.length ;i++){
+				sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
+			}
+			
+			return sb.toString();
+		} 
+		catch (NoSuchAlgorithmException e){
+			e.printStackTrace();
+			return null;
+		}
+	}
+}

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/util/ChecksumUtil.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/util/ChecksumUtil.java
@@ -1,24 +1,12 @@
 package org.cognitor.cassandra.migration.util;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.util.zip.CRC32;
 
 public class ChecksumUtil {
 
-	public static String encryptSHA512(String script){
-		try {
-			MessageDigest md = MessageDigest.getInstance("SHA-512");
-			byte[] bytes = md.digest(script.getBytes());
-			StringBuilder sb = new StringBuilder();
-			for(int i=0; i< bytes.length ;i++){
-				sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
-			}
-			
-			return sb.toString();
-		} 
-		catch (NoSuchAlgorithmException e){
-			e.printStackTrace();
-			return null;
-		}
-	}
+	public static int calculateCRC32(String script) {
+        final CRC32 crc32 = new CRC32();
+        crc32.update(script.getBytes());
+        return (int) crc32.getValue();
+    }
 }


### PR DESCRIPTION
I added ChecksumUtil with CRC32. 

If the Validation flag is on the migrate task will:
1. fetch all scripts
2. validate checksum for scripts with version lower than database version
3. migrate the rest of the scripts
4. return the number of migrated scripts

if the checksum validation failed (for one of the scripts) the migration task will quit without migrating the scripts and return -1.
