### PR TITLE
Check that the schema is in agreement after a schema change

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Multi line comments are not supported.
 
 ## Migrations
 Migrations are executed with the Quorum consistency level by default to make sure that always a majority of nodes share the same schema information.
-Any change to the schema triggers a check for schema agreement. Please read the [Datastax driver documentation](https://docs.datastax.com/en/developer/java-driver/2.1/manual/metadata/#schema-agreement) for more information.
+Any change to the schema triggers a check for schema agreement. Please read the [Datastax driver documentation](https://docs.datastax.com/en/developer/java-driver/3.5/manual/metadata/#schema-agreement) for more information.
 Error handling is not really implemented (and as far as I know not really possible from a database point of view).
 If one script fails the migration is stopped and an exception is thrown. The exception contains the name of
 the failing script as well as the broken statement in case the error happened during the execution of a

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Single line comments are indicated by either '//' or '--' characters.
 Multi line comments are not supported.
 
 ## Migrations
-Migrations are executed with the Quorum consistency level to make sure that always a majority of nodes share the same schema information.
+Migrations are executed with the Quorum consistency level by default to make sure that always a majority of nodes share the same schema information.
+Any change to the schema triggers a check for schema agreement. Please read the [Datastax driver documentation](https://docs.datastax.com/en/developer/java-driver/2.1/manual/metadata/#schema-agreement) for more information.
 Error handling is not really implemented (and as far as I know not really possible from a database point of view).
 If one script fails the migration is stopped and an exception is thrown. The exception contains the name of
 the failing script as well as the broken statement in case the error happened during the execution of a

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
@@ -197,11 +197,18 @@ public class Database implements Closeable {
         }
     }
 
-    private void executeStatement(String statement) {
+    private void executeStatement(String statement) throws DisagreementException {
         if (!statement.isEmpty()) {
             SimpleStatement simpleStatement = new SimpleStatement(statement);
             simpleStatement.setConsistencyLevel(configuration.getConsistencyLevel());
-            session.execute(simpleStatement);
+
+            final ResultSet result = session.execute(simpleStatement);
+
+            // Make sure to interrupt the migration if an agreement cannot be reached.
+            final boolean notInAgreement = !result.getExecutionInfo().isSchemaInAgreement();
+            if(notInAgreement){
+                throw new DisagreementException();
+            }
         }
     }
 

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DisagreementException.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DisagreementException.java
@@ -1,0 +1,7 @@
+package org.cognitor.cassandra.migration;
+
+public class DisagreementException extends Exception {
+    public DisagreementException(){
+        super("Could not reach a schema agreement in time.");
+    }
+}


### PR DESCRIPTION
It would be nice to use the "agreement check" feature from the Datastax Java driver.
Here is an implementation proposal.