### PR TITLE
Change in scope for one dependency. 

### DIFF
--- a/cassandra-migration-spring-boot-starter/pom.xml
+++ b/cassandra-migration-spring-boot-starter/pom.xml
@@ -71,6 +71,7 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>5.0.8.RELEASE</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
It overrides the dependencies versions in the dependency tree, when you run the app on the production environment.