### PR TITLE
Add leader election to avoid schema disagreements with concurrent migrations

### DIFF
--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
@@ -47,7 +47,7 @@ public class CassandraMigrationAutoConfiguration {
         return new MigrationTask(new Database(cluster, properties.getKeyspaceName(), properties.getTablePrefix())
                 .setConsistencyLevel(properties.getConsistencyLevel()),
                 migrationRepository,
-                properties.getWithConsensus());
+                properties.isWithConsensus());
     }
 
     private MigrationRepository createRepository() {

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
@@ -46,7 +46,8 @@ public class CassandraMigrationAutoConfiguration {
         MigrationRepository migrationRepository = createRepository();
         return new MigrationTask(new Database(cluster, properties.getKeyspaceName(), properties.getTablePrefix())
                 .setConsistencyLevel(properties.getConsistencyLevel()),
-                migrationRepository);
+                migrationRepository,
+                properties.getWithConsensus());
     }
 
     private MigrationRepository createRepository() {

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -110,12 +110,12 @@ public class CassandraMigrationConfigurationProperties {
         return this;
     }
 
-    public Boolean getWithConsensus() {
+    public Boolean isWithConsensus() {
         return withConsensus;
     }
 
     /**
-     * Sets wether or not the migration should use consensus to prevent
+     * Sets whether or not the migration should use consensus to prevent
      * concurrent schema updates.
      *
      * @param withConsensus enable/disable leader election for migrations

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -18,6 +18,7 @@ public class CassandraMigrationConfigurationProperties {
     private String keyspaceName;
     private String tablePrefix = "";
     private ConsistencyLevel consistencyLevel = ConsistencyLevel.QUORUM;
+    private Boolean withConsensus = false;
 
     /**
      * @return The location of the migration scripts. Never null.
@@ -107,5 +108,19 @@ public class CassandraMigrationConfigurationProperties {
     public CassandraMigrationConfigurationProperties setTablePrefix(String tablePrefix) {
         this.tablePrefix = tablePrefix;
         return this;
+    }
+
+    public Boolean getWithConsensus() {
+        return withConsensus;
+    }
+
+    /**
+     * Sets wether or not the migration should use consensus to prevent
+     * concurrent schema updates.
+     *
+     * @param withConsensus enable/disable leader election for migrations
+     */
+    public void setWithConsensus(Boolean withConsensus) {
+        this.withConsensus = withConsensus;
     }
 }

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
@@ -32,6 +32,7 @@ public class CassandraMigrationAutoConfigurationTest {
         AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext();
         addEnvironment(context, "cassandra.migration.keyspace-name:test_keyspace");
+        addEnvironment(context, "cassandra.migration.with-consensus:true");
         context.register(ClusterConfig.class, CassandraMigrationAutoConfiguration.class);
         context.refresh();
         Cluster cluster = context.getBean(Cluster.class);

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -33,7 +33,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.IGNORE_DUPLICATES)));
         assertThat(properties.getConsistencyLevel(), is(equalTo(ConsistencyLevel.ALL)));
         assertThat(properties.getTablePrefix(), is(equalTo("prefix")));
-        assertThat(properties.getWithConsensus(), is(true));
+        assertThat(properties.isWithConsensus(), is(true));
     }
 
     @Test
@@ -48,6 +48,6 @@ public class CassandraMigrationConfigurationPropertiesTest {
         assertThat(properties.getScriptLocation(), is(equalTo("cassandra/migration")));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
         assertThat(properties.getTablePrefix(), is(equalTo("")));
-        assertThat(properties.getWithConsensus(), is(false));
+        assertThat(properties.isWithConsensus(), is(false));
     }
 }

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -23,6 +23,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         addEnvironment(context, "cassandra.migration.strategy:IGNORE_DUPLICATES");
         addEnvironment(context, "cassandra.migration.consistency-level:all");
         addEnvironment(context, "cassandra.migration.table-prefix:prefix");
+        addEnvironment(context, "cassandra.migration.with-consensus:true");
         context.register(CassandraMigrationAutoConfiguration.class);
         context.refresh();
         CassandraMigrationConfigurationProperties properties =
@@ -32,6 +33,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.IGNORE_DUPLICATES)));
         assertThat(properties.getConsistencyLevel(), is(equalTo(ConsistencyLevel.ALL)));
         assertThat(properties.getTablePrefix(), is(equalTo("prefix")));
+        assertThat(properties.getWithConsensus(), is(true));
     }
 
     @Test
@@ -46,5 +48,6 @@ public class CassandraMigrationConfigurationPropertiesTest {
         assertThat(properties.getScriptLocation(), is(equalTo("cassandra/migration")));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
         assertThat(properties.getTablePrefix(), is(equalTo("")));
+        assertThat(properties.getWithConsensus(), is(false));
     }
 }

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.cognitor.cassandra.migration.util.Ensure.notNull;
@@ -29,6 +30,11 @@ public class Database implements Closeable {
     private static final String SCHEMA_CF = "schema_migration";
 
     /**
+     * The name of the table that is used for leader election on migrations
+     */
+    private static final String SCHEMA_LEADER_CF = "schema_migration_leader";
+
+    /**
      * Insert statement that logs a migration into the schema_migration table.
      */
     private static final String INSERT_MIGRATION = "insert into %s"
@@ -37,9 +43,15 @@ public class Database implements Closeable {
     /**
      * Statement used to create the table that manages the migrations.
      */
-    private static final String CREATE_MIGRATION_CF = "CREATE TABLE %s"
+    private static final String CREATE_MIGRATION_CF = "CREATE TABLE %s %s"
             + " (applied_successful boolean, version int, script_name varchar, script text,"
             + " executed_at timestamp, PRIMARY KEY (applied_successful, version))";
+
+    /**
+     * Statement used to create the table that manages the leader election on migrations.
+     */
+    private static final String CREATE_LEADER_CF = "CREATE TABLE %s %s"
+            + " (keyspace_name text, leader uuid, took_lead_at timestamp, PRIMARY KEY (keyspace_name))";
 
     /**
      * The query that retrieves current schema version
@@ -49,17 +61,38 @@ public class Database implements Closeable {
                     + "order by version desc limit 1";
 
     /**
+     * The query that attempts to get the lead on schema migrations
+     */
+    private static final String TAKE_LEAD_QUERY =
+            "INSERT INTO %s (keyspace_name, leader, took_lead_at) VALUES (?, ?, dateOf(now())) IF NOT EXISTS USING TTL %s";
+
+    /**
+     * The query that releases the lead on schema migrations
+     */
+    private static final String RELEASE_LEAD_QUERY = "DELETE FROM %s where keyspace_name = ? IF leader = ?";
+
+    /**
      * Error message that is thrown if there is an error during the migration
      */
     private static final String MIGRATION_ERROR_MSG = "Error during migration of script %s while executing '%s'";
 
+    private static final int LEAD_TTL = 300;
+
+    private static final int TAKE_LEAD_WAIT_TIME = 10000;
+
+    private final UUID instanceId = UUID.randomUUID();
     private final String tableName;
+    private final String leaderTableName;
     private final String keyspaceName;
     private final Keyspace keyspace;
     private final Cluster cluster;
     private final Session session;
     private ConsistencyLevel consistencyLevel = ConsistencyLevel.QUORUM;
     private final PreparedStatement logMigrationStatement;
+    private final PreparedStatement takeMigrationLeadStatement;
+    private final PreparedStatement releaseMigrationLeadStatement;
+    private final VersionNumber cassandraVersion;
+    private boolean tookLead = false;
 
     public Database(Cluster cluster, Keyspace keyspace) {
         this(cluster, keyspace, "");
@@ -88,10 +121,15 @@ public class Database implements Closeable {
         this.keyspace = keyspace;
         this.keyspaceName = Optional.ofNullable(keyspace).map(Keyspace::getKeyspaceName).orElse(keyspaceName);
         this.tableName = createTableName(tablePrefix);
+        this.leaderTableName = createLeaderTableName(tablePrefix);
         createKeyspaceIfRequired();
         session = cluster.connect(this.keyspaceName);
+        this.cassandraVersion = cluster.getMetadata().getAllHosts().stream().map(h -> h.getCassandraVersion())
+                .min(VersionNumber::compareTo).get();
         ensureSchemaTable();
         this.logMigrationStatement = session.prepare(format(INSERT_MIGRATION, getTableName()));
+        this.takeMigrationLeadStatement = session.prepare(format(TAKE_LEAD_QUERY, getLeaderTableName(), LEAD_TTL));
+        this.releaseMigrationLeadStatement = session.prepare(format(RELEASE_LEAD_QUERY, getLeaderTableName()));
     }
 
     private static String createTableName(String tablePrefix) {
@@ -99,6 +137,13 @@ public class Database implements Closeable {
             return SCHEMA_CF;
         }
         return String.format("%s_%s", tablePrefix, SCHEMA_CF);
+    }
+
+    private static String createLeaderTableName(String tablePrefix) {
+      if (tablePrefix == null || tablePrefix.isEmpty()) {
+          return SCHEMA_LEADER_CF;
+      }
+      return String.format("%s_%s", tablePrefix, SCHEMA_LEADER_CF);
     }
 
     private void createKeyspaceIfRequired() {
@@ -121,6 +166,7 @@ public class Database implements Closeable {
      * and will stay open. Call this after all migrations are done.
      * After calling this, this database instance can no longer be used.
      */
+    @Override
     public void close() {
         this.session.close();
     }
@@ -132,7 +178,9 @@ public class Database implements Closeable {
      * @return the current schema version
      */
     public int getVersion() {
-        ResultSet resultSet = session.execute(format(VERSION_QUERY, getTableName()));
+        Statement getVersionQuery = new SimpleStatement(format(VERSION_QUERY, getTableName()))
+                .setConsistencyLevel(this.consistencyLevel);
+        ResultSet resultSet = session.execute(getVersionQuery);
         Row result = resultSet.one();
         if (result == null) {
             return 0;
@@ -153,6 +201,10 @@ public class Database implements Closeable {
         return tableName;
     }
 
+    public String getLeaderTableName() {
+        return leaderTableName;
+    }
+
     /**
      * Makes sure the schema migration table exists. If it is not available it will be created.
      */
@@ -165,12 +217,16 @@ public class Database implements Closeable {
     private boolean schemaTablesIsNotExisting() {
         Metadata metadata = cluster.getMetadata();
         KeyspaceMetadata keyspace = metadata.getKeyspace(keyspaceName);
-        TableMetadata table = keyspace.getTable(getTableName());
-        return table == null;
+        Optional<TableMetadata> table = Optional.ofNullable(keyspace.getTable(getTableName()));
+        Optional<TableMetadata> leaderTable = Optional.ofNullable(keyspace.getTable(getLeaderTableName()));
+        return !(table.isPresent() && leaderTable.isPresent());
     }
 
     private void createSchemaTable() {
-        session.execute(format(CREATE_MIGRATION_CF, getTableName()));
+        // "IF NOT EXISTS" is only available starting from Cassandra 2.0
+        String ifNotExistsString = 0 >= VersionNumber.parse("2.0").compareTo(cassandraVersion) ? "IF NOT EXISTS" : "";
+        session.execute(format(CREATE_MIGRATION_CF, ifNotExistsString, getTableName()));
+        session.execute(format(CREATE_LEADER_CF, ifNotExistsString, getLeaderTableName()));
     }
 
     /**
@@ -240,5 +296,74 @@ public class Database implements Closeable {
     public Database setConsistencyLevel(ConsistencyLevel consistencyLevel) {
         this.consistencyLevel = notNull(consistencyLevel, "consistencyLevel");
         return this;
+    }
+
+    /**
+     * Attempts to acquire the lead on a migration through a LightWeight
+     * Transaction.
+     *
+     * @param repositoryLatestVersion
+     *            the latest version number in the migration repository
+     * @return if taking the lead succeeded
+     */
+    boolean takeLeadOnMigrations(int repositoryLatestVersion) {
+        if (VersionNumber.parse("2.0").compareTo(cassandraVersion) > 0) {
+            // No LWT before Cassandra 2.0 so leader election can't happen
+            return true;
+        }
+
+        while (repositoryLatestVersion > getVersion()) {
+            try {
+                LOGGER.debug("Trying to take lead on schema migrations");
+                BoundStatement boundStatement = takeMigrationLeadStatement.bind(getKeyspaceName(), this.instanceId);
+                ResultSet lwtResult = session.execute(boundStatement);
+
+                if (lwtResult.wasApplied()) {
+                    LOGGER.debug("Took lead on schema migrations");
+                    tookLead = true;
+                    return true;
+                }
+
+                LOGGER.info("Schema migration is locked by another instance. Waiting for it to be released...");
+                waitFor(TAKE_LEAD_WAIT_TIME);
+            } catch (com.datastax.driver.core.exceptions.InvalidQueryException e1) {
+                // A little redundant but necessary
+                LOGGER.info("All required tables do not exist yet, waiting for them to be created...");
+                waitFor(TAKE_LEAD_WAIT_TIME);
+            }
+        }
+
+        return false;
+    }
+
+    private void waitFor(int waitTime) {
+        try {
+            Thread.sleep(waitTime);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Attempts to release the lead on schema migrations, if it was taken by the
+     * local process.
+     */
+    void removeLeadOnMigrations() {
+        if (tookLead) {
+            LOGGER.debug("Trying to take lead on schema migrations");
+
+            BoundStatement boundStatement = releaseMigrationLeadStatement.bind(getKeyspaceName(), this.instanceId);
+            ResultSet lwtResult = session.execute(boundStatement);
+
+            if (lwtResult.wasApplied()) {
+                LOGGER.debug("Released lead on schema migrations");
+                tookLead = false;
+                return;
+            }
+            // Another instance took the lead on migrations?
+            // Otherwise, TTL will do the trick
+            LOGGER.error("Could not release lead on schema migrations");
+            return;
+        }
     }
 }

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationTask.java
@@ -38,6 +38,7 @@ public class MigrationTask {
      *
      * @param database the database that should be migrated
      * @param repository the repository that contains the migration scripts
+     * @param withConsensus if the migration should be handled by a single process at once, using LWT based leader election
      */
     public MigrationTask(Database database, MigrationRepository repository, boolean withConsensus) {
         this.database = notNull(database, "database");

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
@@ -4,6 +4,8 @@ import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.google.common.collect.Lists;
+
 import org.cognitor.cassandra.CassandraJUnitRule;
 import org.cognitor.cassandra.migration.Database;
 import org.cognitor.cassandra.migration.MigrationException;
@@ -15,6 +17,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static org.cognitor.cassandra.CassandraJUnitRule.DEFAULT_SCRIPT_LOCATION;
 import static org.hamcrest.CoreMatchers.*;
@@ -84,6 +92,60 @@ public class DatabaseTest {
         assertThat(results.get(2).getTimestamp("executed_at"), is(not(nullValue())));
         assertThat(results.get(2).getString("script_name"), is(equalTo("003_add_another_table.cql")));
         assertThat(results.get(2).getString("script"), is(equalTo("CREATE TABLE THINGS (thing_id uuid primary key, thing_name varchar);")));
+    }
+
+    @Test
+    public void shouldApplyConcurrentMigrationsToDatabaseWhenMigrationsAndEmptyDatabaseGiven()
+            throws InterruptedException, ExecutionException {
+        int concurrentTasks = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(concurrentTasks);
+        List<Database> databases = Lists.newArrayList();
+        List<MigrationTask> migrationTasks = Lists.newArrayList();
+
+        for (int i = 0; i < concurrentTasks; i++) {
+            databases.add(new Database(cassandra.getCluster(), CassandraJUnitRule.TEST_KEYSPACE));
+            migrationTasks.add(
+                    new MigrationTask(
+                            databases.get(i),
+                            new MigrationRepository("cassandra/migrationtest/successful"),
+                            true));
+        }
+
+        List<Callable<Boolean>> migrations = migrationTasks.stream().map(task -> databaseMigrationTask(task))
+                .collect(Collectors.toList());
+
+        // Executing the same migration concurrently with different threads
+        List<Future<Boolean>> futures = executorService.invokeAll(migrations);
+        for (Future<Boolean> future : futures) {
+            future.get();
+        }
+
+        Database database = new Database(cassandra.getCluster(), CassandraJUnitRule.TEST_KEYSPACE);
+        assertThat(database.getVersion(), is(equalTo(3)));
+
+        List<Row> results = loadMigrations("");
+        assertThat(results.size(), is(equalTo(3)));
+        assertThat(results.get(0).getBool("applied_successful"), is(true));
+        assertThat(results.get(0).getTimestamp("executed_at"), is(not(nullValue())));
+        assertThat(results.get(0).getString("script_name"), is(equalTo("001_init.cql")));
+        assertThat(results.get(0).getString("script"), is(startsWith("CREATE TABLE")));
+        assertThat(results.get(1).getBool("applied_successful"), is(true));
+        assertThat(results.get(1).getTimestamp("executed_at"), is(not(nullValue())));
+        assertThat(results.get(1).getString("script_name"), is(equalTo("002_add_events_table.cql")));
+        assertThat(results.get(1).getString("script"),
+                is(equalTo("CREATE TABLE EVENTS (event_id uuid primary key, event_name varchar);")));
+        assertThat(results.get(2).getBool("applied_successful"), is(true));
+        assertThat(results.get(2).getTimestamp("executed_at"), is(not(nullValue())));
+        assertThat(results.get(2).getString("script_name"), is(equalTo("003_add_another_table.cql")));
+        assertThat(results.get(2).getString("script"),
+                is(equalTo("CREATE TABLE THINGS (thing_id uuid primary key, thing_name varchar);")));
+    }
+
+    Callable<Boolean> databaseMigrationTask(MigrationTask migrationTask) {
+        return () -> {
+            migrationTask.migrate();
+            return true;
+        };
     }
 
     @Test

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
@@ -4,8 +4,10 @@ import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.VersionNumber;
 import com.google.common.collect.Lists;
 
+import org.apache.tools.ant.taskdefs.condition.IsTrue;
 import org.cognitor.cassandra.CassandraJUnitRule;
 import org.cognitor.cassandra.migration.Database;
 import org.cognitor.cassandra.migration.MigrationException;
@@ -228,5 +230,20 @@ public class DatabaseTest {
         }
         return session.execute(
                 new SimpleStatement(String.format("SELECT * FROM %s_schema_migration;", tablePrefix))).all();
+    }
+
+    @Test
+    public void testCassandraVersionCheck() {
+        Database database = new Database(cassandra.getCluster(), CassandraJUnitRule.TEST_KEYSPACE);
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("1.1.14")), is(false));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("1.2.19")), is(false));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("2.0.10")), is(true));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("2.1.19")), is(true));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("2.2.14")), is(true));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("3.0.15")), is(true));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("3.11.4")), is(true));
+        assertThat(database.isVersionAtLeastV2(VersionNumber.parse("4.0")), is(true));
+        database.close();
+
     }
 }


### PR DESCRIPTION
When starting multiple distributed processes at the same time, migrations will be executed at the same time, often resulting in schema conflicts.
This commit adds leader election through LWTs so that only a single process will perform the migration at once on a given keyspace.
Leader election will be optional and deactivated by default.
`IF NOT EXISTS` clauses were added to the `CREATE TABLE` statements in order to avoid conflicts there as well.
Both changes are disabled if the Cassandra version is below 2.0 since we would miss both LWTs and `IF NOT EXISTS` features.

We're using this lib in [Reaper](https://github.com/thelastpickle/cassandra-reaper) and we're moving towards more concurrency with the introduction of the sidecar mode, which creates more risks of getting schema disagreements without proper consensus. We've implemented it in our latest `master` but feel that this mechanism should be provided by the migration lib.

I made it so that the default remains the same, and automatically disabled features that didn't exist in 1.2 in case you want to keep supporting old versions of Cassandra.