### PR TITLE
Make Mockito Test Scope in Maven Dependency Management

### DIFF
--- a/cassandra-migration-spring-boot-starter/pom.xml
+++ b/cassandra-migration-spring-boot-starter/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.10.19</version>
+                <scope>test</test>
+            </dependency>
+            <dependency>
                 <groupId>org.cassandraunit</groupId>
                 <artifactId>cassandra-unit</artifactId>
                 <version>3.0.0.1</version>


### PR DESCRIPTION
We don't want to have mockito being passed down in compile time dependencies.