### PR TITLE
Add support for AWS MCS (Amazon Keyspaces)

### DIFF
--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/AwsMcsExecutor.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/AwsMcsExecutor.java
@@ -1,0 +1,187 @@
+package org.cognitor.cassandra.migration.executors;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import java.lang.invoke.MethodHandles;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.cognitor.cassandra.migration.MigrationException;
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult;
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult.DDLType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AwsMcsExecutor implements Executor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final CqlSession session;
+
+    private Executor delegateExecutor;
+    DDLRecogniser ddlRecogniser = new DDLRecogniser();
+
+    private static final int[] QUERY_INTERVALS_MILIS = new int[]{ 50, 100, 300, 600, 1000 };
+    //MCS: countRows is not yet supported.
+    private static final String KEYSPACE_OPERATION_CHECK_QUERY = "SELECT * FROM system_schema_mcs.keyspaces WHERE keyspace_name = '%s'";
+
+    private static final String TABLE_OPERATION_CHECK_QUERY = "SELECT keyspace_name, table_name, status FROM system_schema_mcs.tables WHERE keyspace_name = '%s' AND table_name = '%s'";
+
+    public AwsMcsExecutor(CqlSession session) {
+        this.session = session;
+        //aws requires LOCAL_QUORUM consistency
+        delegateExecutor = new SimpleExecutor(session, DefaultConsistencyLevel.LOCAL_QUORUM);
+    }
+
+    @Override
+    public ResultSet execute(String statement, Object... parameters) {
+        ResultSet resultSet = delegateExecutor.execute(statement, parameters);
+        waitIfNecessary(statement);
+        return resultSet;
+    }
+
+    @Override
+    public ResultSet execute(String statement) {
+        ResultSet resultSet = delegateExecutor.execute(statement);
+        waitIfNecessary(statement);
+        return resultSet;
+    }
+
+    @Override
+    public ResultSet execute(String statement, String executionProfileName) {
+        ResultSet resultSet = delegateExecutor.execute(statement, executionProfileName);
+        waitIfNecessary(statement);
+        return resultSet;
+    }
+
+    @Override
+    public boolean keyspaceExists(String keyspaceName) {
+        return delegateExecutor.keyspaceExists(keyspaceName);
+    }
+
+    @Override
+    public boolean tableExists(String keyspaceName, String tableName) {
+        return delegateExecutor.tableExists(keyspaceName, tableName);
+    }
+
+    @Override
+    public ConsistencyLevel getConsistencyLevel() {
+        return delegateExecutor.getConsistencyLevel();
+    }
+
+    @Override
+    public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        delegateExecutor.setConsistencyLevel(consistencyLevel);
+    }
+
+    @Override
+    public void close() {
+        delegateExecutor.close();
+    }
+
+    private void waitIfNecessary(String statement) {
+        DDLRecogniserResult statementType = ddlRecogniser.evaluate(statement);
+        if(statementType.isAsyncDDL()) {
+            if(statementType.isKeyspaceDDL()) {
+                if(statementType.getDdlType() != DDLType.CREATE) {
+                    LOGGER.warn("No wait support for async " + statementType.getDdlType() + " operation. Only CREATE KEYSPACE is supported!");
+                    return;
+                }
+                waitForKeyspaceCreation(statementType.getResourceName());
+            } else if (statementType.isTableDDL()) {
+                waitForTableCreation(statementType.getResourceName(), statementType.getDdlType());
+            }
+        }
+    }
+
+    //no support for DROP KEYSPACE
+    //don't know how to detect when ALTER KEYSPACE is finished (also no support)
+    private void waitForKeyspaceCreation(String resourceName) {
+        int keyspaces = 0;
+        LOGGER.debug("Witing for completing the creation of " + resourceName);
+        long startTime = System.currentTimeMillis();
+        int count = 0;
+        while(keyspaces == 0) {
+            //looks like keyspace name is transformed to lowercase by cassandra on AWS
+            ResultSet resultSet = executeInternal(String.format(KEYSPACE_OPERATION_CHECK_QUERY, resourceName.toLowerCase()));
+            keyspaces = resultSet.all().size();
+            if(keyspaces > 0) {
+                continue;
+            }
+            try{
+                Thread.sleep(QUERY_INTERVALS_MILIS[count >= QUERY_INTERVALS_MILIS.length ? (QUERY_INTERVALS_MILIS.length - 1) : count]);
+                count++;
+            } catch (InterruptedException e) {
+                throw new MigrationException("Interrupted while waiting for " + resourceName + " completion.", e);
+            }
+        }
+        long duration = System.currentTimeMillis() - startTime;
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault());
+        LOGGER.debug(resourceName + " creation duration: " + sdf.format(new Date(duration - TimeZone.getDefault().getRawOffset())));
+    }
+
+    private void waitForTableCreation(String resourceName, DDLType ddlType) {
+        long startTime = System.currentTimeMillis();
+        if(ddlType == DDLType.CREATE || ddlType == DDLType.ALTER || ddlType == DDLType.RESTORE) {
+            LOGGER.debug("Witing for completing the " + ddlType + " operation of " + resourceName);
+            boolean active = false;
+            int count = 0;
+            while(active == false) {
+                String query = String.format(TABLE_OPERATION_CHECK_QUERY, session.getKeyspace().get().asInternal(), resourceName.toLowerCase());
+                ResultSet resultSet = executeInternal(query);
+                Row row = resultSet.one();
+                if(row != null) {
+                    String status = row.getString("status");
+                    if ("ACTIVE".equalsIgnoreCase(status)) {
+                        active = true;
+                        continue;
+                    }
+                }
+                try{
+                    Thread.sleep(QUERY_INTERVALS_MILIS[count >= QUERY_INTERVALS_MILIS.length ? (QUERY_INTERVALS_MILIS.length - 1) : count]);
+                    count++;
+                } catch (InterruptedException e) {
+                    throw new MigrationException("Interrupted while waiting for " + resourceName + " completion.", e);
+                }
+            }
+            long duration = System.currentTimeMillis() - startTime;
+            SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault());
+            LOGGER.debug(resourceName + " creation duration: " + sdf.format(new Date(duration - TimeZone.getDefault().getRawOffset())));
+        } else if(ddlType == DDLType.DROP) {
+            LOGGER.debug("Witing for completing the " + ddlType + " operation of " + resourceName);
+            boolean deleted = false;
+            int count = 0;
+            while(deleted == false) {
+                String query = String.format(TABLE_OPERATION_CHECK_QUERY, session.getKeyspace().get().asInternal(), resourceName.toLowerCase());
+                ResultSet resultSet = executeInternal(query);
+                Row row = resultSet.one();
+                if (row == null) {
+                    deleted = true;
+                    continue;
+                }
+                try{
+                    Thread.sleep(QUERY_INTERVALS_MILIS[count >= QUERY_INTERVALS_MILIS.length ? (QUERY_INTERVALS_MILIS.length - 1) : count]);
+                    count++;
+                } catch (InterruptedException e) {
+                    throw new MigrationException("Interrupted while waiting for " + resourceName + " completion.", e);
+                }
+            }
+            long duration = System.currentTimeMillis() - startTime;
+            SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault());
+            LOGGER.debug(resourceName + " creation duration: " + sdf.format(new Date(duration - TimeZone.getDefault().getRawOffset())));
+        } else {
+            LOGGER.warn("DDL type " + ddlType + " not handled for " + resourceName);
+        }
+    }
+
+    //not using delegateExecutor to prevent logging from SimpleExecutor
+    private ResultSet executeInternal(String statement) {
+        SimpleStatement simpleStatement = SimpleStatement.newInstance(statement);
+        LOGGER.trace("aws mcs check query: " + statement);
+        return session.execute(simpleStatement);
+    }
+}

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/DDLRecogniser.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/DDLRecogniser.java
@@ -1,0 +1,136 @@
+package org.cognitor.cassandra.migration.executors;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult;
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult.DDLType;
+
+/**
+ * Needs to be extended to return if is either CREATE, ALTER or DROP
+ */
+public class DDLRecogniser {
+    private List<DDLDetector> detectors = Arrays.asList(new KeyspaceDetector(), new TableDetector());
+
+    public DDLRecogniserResult evaluate(String cql) {
+        for(DDLDetector detector : detectors){
+            DDLRecogniserResult result = detector.getResult(cql);
+            if(result.isAsyncDDL) {
+                return result;
+            }
+        }
+        return DDLRecogniserResult.nonAsyncDDL();
+    }
+
+    static class DDLRecogniserResult {
+        public static enum DDLType {
+            CREATE,
+            ALTER,
+            DROP,
+            RESTORE
+        }
+
+        private boolean isAsyncDDL;
+        private boolean isKeyspaceDDL;
+        private boolean isTableDDL;
+        private String resourceName;
+        private DDLType ddlType;
+
+        public static DDLRecogniserResult nonAsyncDDL() {
+            return new DDLRecogniserResult();
+        }
+
+        public static DDLRecogniserResult asyncKeyspaceDDL(String keyspaceName, DDLType ddlType) {
+            DDLRecogniserResult result = new DDLRecogniserResult();
+            result.isAsyncDDL = true;
+            result.isKeyspaceDDL = true;
+            result.resourceName = keyspaceName;
+            result.ddlType = ddlType;
+            return result;
+        }
+
+        public static DDLRecogniserResult asyncTableDDL(String keyspaceName, DDLType ddlType) {
+            DDLRecogniserResult result = new DDLRecogniserResult();
+            result.isAsyncDDL = true;
+            result.isTableDDL = true;
+            result.resourceName = keyspaceName;
+            result.ddlType = ddlType;
+            return result;
+        }
+
+        public boolean isAsyncDDL() {
+            return isAsyncDDL;
+        }
+
+        public boolean isNotAsyncDDL() {
+            return !isAsyncDDL;
+        }
+
+        public boolean isKeyspaceDDL() {
+            return isKeyspaceDDL;
+        }
+
+        public boolean isTableDDL() {
+            return isTableDDL;
+        }
+
+        public String getResourceName() {
+            return resourceName;
+        }
+
+        public DDLType getDdlType() {
+            return ddlType;
+        }
+    }
+
+}
+
+abstract class DDLDetector {
+    Pattern pattern;
+    abstract DDLRecogniserResult getResult(String cql);
+}
+
+
+class KeyspaceDetector extends DDLDetector {
+    //recognise these statements:
+    //CREATE KEYSPACE [ IF NOT EXISTS ] keyspace_name
+    //ALTER KEYSPACE keyspace_name
+    //DROP KEYSPACE [ IF EXISTS ] keyspace_name
+
+    public KeyspaceDetector() {
+        pattern = Pattern.compile("\\s*(CREATE|ALTER|DROP)\\s+KEYSPACE\\s+(IF\\s+NOT\\s+EXISTS\\s+)?(\\w+|\"\\w+\")(\\s+|$)", Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    DDLRecogniserResult getResult(String cql) {
+        Matcher matcher = pattern.matcher(cql);
+        if(!matcher.find()) {
+            return DDLRecogniserResult.nonAsyncDDL();
+        }
+        DDLType ddlType = DDLType.valueOf(matcher.group(1).trim().toUpperCase());
+        return DDLRecogniserResult.asyncKeyspaceDDL(matcher.group(3).replaceAll("\"", ""), ddlType);
+    }
+}
+
+class TableDetector extends DDLDetector {
+    //recognise these statements:
+    // CREATE TABLE [ IF NOT EXISTS ] table_name (...
+    // ALTER TABLE table_name ...
+    // RESTORE TABLE table_name FROM TABLE ...
+    // DROP TABLE [ IF EXISTS ] table_name
+
+    public TableDetector() {
+        pattern = Pattern.compile("\\s*(CREATE|ALTER|RESTORE|DROP)\\s+TABLE\\s+(IF\\s+(NOT\\s+)?EXISTS\\s+)?(\\w+|\"\\w+\")(\\s+|$)", Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    DDLRecogniserResult getResult(String cql) {
+        Matcher matcher = pattern.matcher(cql);
+        if(!matcher.find()) {
+            return DDLRecogniserResult.nonAsyncDDL();
+        }
+        DDLType ddlType = DDLType.valueOf(matcher.group(1).trim().toUpperCase());
+        return DDLRecogniserResult.asyncTableDDL(matcher.group(4).replaceAll("\"", ""), ddlType);
+    }
+}

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/Executor.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/Executor.java
@@ -1,0 +1,17 @@
+package org.cognitor.cassandra.migration.executors;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import java.util.Optional;
+
+public interface Executor {
+    ResultSet execute(String statement, Object... parameters);
+    ResultSet execute(String statement);
+    ResultSet execute(String statement, String executionProfileName);
+    boolean keyspaceExists(String keyspaceName);
+    boolean tableExists(String keyspaceName, String tableName);
+    ConsistencyLevel getConsistencyLevel();
+    void setConsistencyLevel(ConsistencyLevel consistencyLevel);
+    void close();
+}

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/ExecutorDetector.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/ExecutorDetector.java
@@ -1,0 +1,31 @@
+package org.cognitor.cassandra.migration.executors;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+
+public class ExecutorDetector {
+    private final CqlSession session;
+
+    private final String mcsSchemaName = "system_schema_mcs";
+    private final String mcsClusterName = "Amazon Keyspaces";
+
+    public ExecutorDetector(CqlSession session) {
+        this.session = session;
+    }
+
+    public Executor getExecutor() {
+        if(isAwsMcs()) {
+            return new AwsMcsExecutor(session);
+        }
+        return new SimpleExecutor(session);
+    }
+
+    private boolean isAwsMcs() {
+        if(!session.getMetadata().getKeyspace(mcsSchemaName).isPresent()){
+            return false;
+        }
+        if(!session.getMetadata().getClusterName().isPresent()) {
+            return false;
+        }
+        return session.getMetadata().getClusterName().get().equalsIgnoreCase(mcsClusterName);
+    }
+}

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/SimpleExecutor.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/executors/SimpleExecutor.java
@@ -1,0 +1,82 @@
+package org.cognitor.cassandra.migration.executors;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import java.lang.invoke.MethodHandles;
+import org.cognitor.cassandra.migration.Database;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SimpleExecutor implements Executor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final CqlSession session;
+    private ConsistencyLevel consistencyLevel;
+
+    public SimpleExecutor(CqlSession session) {
+        this(session, DefaultConsistencyLevel.QUORUM);
+    }
+
+    public SimpleExecutor(CqlSession session, ConsistencyLevel consistencyLevel) {
+        this.session = session;
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public ResultSet execute(String statement, Object... parameters) {
+        PreparedStatement preparedStatement = this.session.prepare(statement);
+        BoundStatement boundStatement = preparedStatement.bind(parameters).setConsistencyLevel(consistencyLevel);
+        LOGGER.debug("Executing: " + statement);
+        return session.execute(boundStatement);
+    }
+
+    @Override
+    public ResultSet execute(String statement) {
+        return execute(statement, (String)null);
+    }
+
+    @Override
+    public ResultSet execute(String statement, String executionProfileName) {
+        SimpleStatement simpleStatement = SimpleStatement.newInstance(statement)
+                .setConsistencyLevel(this.consistencyLevel);
+        if(executionProfileName != null) {
+            simpleStatement.setExecutionProfileName(executionProfileName);
+        }
+        LOGGER.debug("Executing: " + statement);
+        return session.execute(simpleStatement);
+    }
+
+    @Override
+    public boolean keyspaceExists(String keyspaceName) {
+        return session.getMetadata().getKeyspace(keyspaceName).isPresent();
+    }
+
+    @Override
+    public boolean tableExists(String keyspaceName, String tableName) {
+        return session.getMetadata()
+                .getKeyspace(keyspaceName)
+                .map(keyspaceMetadata -> keyspaceMetadata.getTable(tableName).isPresent())
+                .orElse(false);
+    }
+
+    @Override
+    public ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    @Override
+    public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+    }
+
+    @Override
+    public void close() {
+        session.close();
+    }
+}

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/executors/DDLDetectorTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/executors/DDLDetectorTest.java
@@ -1,0 +1,75 @@
+package org.cognitor.cassandra.migration.executors;
+
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult;
+import org.cognitor.cassandra.migration.executors.DDLRecogniser.DDLRecogniserResult.DDLType;
+import org.cognitor.cassandra.migration.keyspace.Keyspace;
+import org.cognitor.cassandra.migration.keyspace.NetworkStrategy;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Patrick Kranz
+ */
+public class DDLDetectorTest {
+
+    private String[][] validKeyspaceDDLs = new String[][] {
+            {"CREATE KEYSPACE IF NOT EXISTS testKeyspace WITH REPLICATION = {\n'class' : 'SimpleStrategy', \n 'replication_factor' : 1 \n  }", "testKeyspace", "CREATE"},
+            {"CREATE KEYSPACE testKeyspace WITH REPLICATION = {\n'class' : 'SimpleStrategy', \n 'replication_factor' : 1 \n  }", "testKeyspace", "CREATE"},
+            {"create keyspace \"test_Keyspace_1\" with replication = {\n'class' : 'SimpleStrategy', \n 'replication_factor' : 1 \n  }", "test_Keyspace_1", "CREATE"},
+            {"create \t  \nkeyspace \t  \n \"test_Keyspace_1\"  \t  \nwith \t  \n replication = {\n'class' : 'SimpleStrategy', \n 'replication_factor' : 1 \n  }", "test_Keyspace_1", "CREATE"}
+    };
+
+    private String[][] validTableDDLs = new String[][]{
+            { "CREATE TABLE my_table (id int, division text, PRIMARY KEY (id,division))",  "my_table", "CREATE" },
+            { "CREATE TABLE IF NOT EXISTS my_table (id int, division text, PRIMARY KEY (id,division))",  "my_table", "CREATE" },
+            { "create table \"my_table\" (id int, division text, PRIMARY KEY (id,division))",  "my_table", "CREATE" },
+            { "ALTER TABLE employees_tbl ADD (first_name text);",  "employees_tbl", "ALTER" },
+            { "ALTER TABLE mytable WITH custom_properties={'point_in_time_recovery': {'status': 'enabled'}}",  "mytable", "ALTER" },
+            { "RESTORE TABLE mytable_restored from table mykeyspace.my_table WITH restore_timestamp = '2020-06-30T04:05:00+0000'",  "mytable_restored", "RESTORE" },
+            { "DROP TABLE IF NOT EXISTS table_name",  "table_name", "DROP" }
+    };
+
+    private String[] nonDDLStatements = new String[] {
+            "INSERT INTO AUTH_USER (email, userId, passwordHash, passwordSalt) VALUES ('tibi@localhost', 18024703-a8f0-40fa-b963-3f9a429d0909, '133137649eff792ed95bf406ab3e413a81fa6a42fb05f658eb38f5cc8299a85997561ddc8f', '3339fee7b51105f8');",
+            "UPDATE cyclists SET firstname = 'Marianne', lastname = 'VOS' WHERE id = 88b8fd18-b1ed-4e96-bf79-4280797cba80"
+    };
+
+    @Test
+    public void shouldDetectKeyspaceOperationAndReturnKeyspaceName() {
+        for(String[] ddl : validKeyspaceDDLs){
+            DDLRecogniser recogniser = new DDLRecogniser();
+            DDLRecogniserResult result = recogniser.evaluate(ddl[0]);
+            assertTrue(result.isAsyncDDL());
+            assertTrue(result.isKeyspaceDDL());
+            assertEquals(ddl[1], result.getResourceName());
+            assertEquals(DDLType.valueOf(ddl[2]), result.getDdlType());
+        }
+    }
+
+    @Test
+    public void shouldDetectTableOperationAndReturnKeyspaceName() {
+        for(String[] ddl : validTableDDLs){
+            DDLRecogniser recogniser = new DDLRecogniser();
+            DDLRecogniserResult result = recogniser.evaluate(ddl[0]);
+            assertTrue(result.isAsyncDDL());
+            assertTrue(result.isTableDDL());
+            assertEquals(ddl[1], result.getResourceName());
+            assertEquals(DDLType.valueOf(ddl[2]), result.getDdlType());
+        }
+    }
+
+    @Test
+    public void shouldDetectNonDDLStatements() {
+        for(String statement : nonDDLStatements){
+            DDLRecogniser recogniser = new DDLRecogniser();
+            DDLRecogniserResult result = recogniser.evaluate(statement);
+            assertTrue(result.isNotAsyncDDL());
+        }
+    }
+
+}


### PR DESCRIPTION
AWS MCS executes all DDLs asynchronously. 
As discussed in
[issue 51](https://github.com/patka/cassandra-migration/issues/51)
after executing a ddl, the tables are not ready only after some time and the subsequent migration scripts will fail.
I've added support for an "Executor" of cql statements. The default one (SimpleExecutor) only forwards to the CqlSession.
There is support in org.cognitor.cassandra.migration.Database for autodetecting if it running against aws and choose AwsMcsExecutor instead of SimpleExecutor. 

AwsMcsExecutor detects if there is a ddl to be executed, extract the name of the table or keyspace, then pause the execution until the table or keyspace is ready.

There is not yet support for DROP KEYSPACE and ALTER KEYSPACE. It is tested with my use case with few create table and insert statements.
