### PR TITLE
Added gracefully fail mechanism on batch migration

### DIFF
--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/DbMigration.java
@@ -9,7 +9,7 @@ import static org.cognitor.cassandra.migration.util.Ensure.notNullOrEmpty;
  *
  * @author Patrick Kranz
  */
-class DbMigration {
+public class DbMigration {
     private final String migrationScript;
     private final String scriptName;
     private final int version;

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
@@ -253,4 +253,13 @@ public class DatabaseTest {
         MigrationTask migrationTask = new MigrationTask(database, repository);
         migrationTask.migrate();
     }
+
+    @Test
+    public void shoulRunBatchMigration() {
+        Database database = new Database(cassandra.getCluster(), CassandraJUnitRule.TEST_KEYSPACE);
+        MigrationRepository repository = new MigrationRepository("cassandra/migrationtest/batch");
+        MigrationTask migrationTask = new MigrationTask(database, repository);
+        migrationTask.setShouldFailGracefully(true);
+        migrationTask.migrate();
+    }
 }

--- a/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/001_create.cql
+++ b/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/001_create.cql
@@ -1,0 +1,1 @@
+CREATE TABLE PERSON (id uuid primary key, name varchar);

--- a/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/002_alter.cql
+++ b/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/002_alter.cql
@@ -1,0 +1,1 @@
+ALTER TABLE PERSON ADD username text;

--- a/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/003_alter.cql
+++ b/cassandra-migration/src/test/resources/cassandra/migrationtest/batch/003_alter.cql
@@ -1,0 +1,1 @@
+ALTER TABLE PERSON ADD username text;


### PR DESCRIPTION
**What does this PR do?**

This PR:
- add a property `shouldFailGracefully` to `MigrationTask` in order to better control what happens when, in a batch script migration, of the scripts fail
- makes `DbMigration` public class in order for it to be extended
- makes `databaseIsUpToDate` protected in order for it to be overridden
- adds getter for the properties of `MigrationTask` and setter for `shouldFailGracefully`