### PR TITLE
Use execution config for table creation

### DIFF
--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
@@ -2,6 +2,7 @@ package org.cognitor.cassandra.migration.spring;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import org.cognitor.cassandra.migration.Database;
+import org.cognitor.cassandra.migration.MigrationConfiguration;
 import org.cognitor.cassandra.migration.MigrationRepository;
 import org.cognitor.cassandra.migration.MigrationTask;
 import org.cognitor.cassandra.migration.collector.FailOnDuplicatesCollector;
@@ -46,7 +47,11 @@ public class CassandraMigrationAutoConfiguration {
         }
 
         MigrationRepository migrationRepository = createRepository();
-        return new MigrationTask(new Database(cqlSession, properties.getKeyspaceName(), properties.getTablePrefix(), properties.getExecutionProfileName())
+        MigrationConfiguration configuration = new MigrationConfiguration()
+                .withKeyspaceName(properties.getKeyspaceName())
+                .withTablePrefix(properties.getTablePrefix())
+                .withExecutionProfile(properties.getExecutionProfileName());
+        return new MigrationTask(new Database(cqlSession, configuration)
                 .setConsistencyLevel(properties.getConsistencyLevel()),
                 migrationRepository,
                 properties.isWithConsensus());

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
@@ -46,8 +46,7 @@ public class CassandraMigrationAutoConfiguration {
         }
 
         MigrationRepository migrationRepository = createRepository();
-        return new MigrationTask(new Database(cqlSession, properties.getKeyspaceName(), properties.getTablePrefix())
-                .setExecutionProfileName(properties.getExecutionProfileName())
+        return new MigrationTask(new Database(cqlSession, properties.getKeyspaceName(), properties.getTablePrefix(), properties.getExecutionProfileName())
                 .setConsistencyLevel(properties.getConsistencyLevel()),
                 migrationRepository,
                 properties.isWithConsensus());

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationConfiguration.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationConfiguration.java
@@ -8,6 +8,7 @@ public class MigrationConfiguration {
     public final String EMPTY_TABLE_PREFIX = "";
     private String tablePrefix = EMPTY_TABLE_PREFIX;
     private Keyspace keyspace;
+    private String executionProfile;
 
     public MigrationConfiguration withKeyspaceName(String keyspaceName) {
         this.keyspace = new Keyspace(keyspaceName);
@@ -27,12 +28,21 @@ public class MigrationConfiguration {
         return this;
     }
 
+    public MigrationConfiguration withExecutionProfile(String executionProfile) {
+        this.executionProfile = executionProfile;
+        return this;
+    }
+
     public String getTablePrefix() {
         return tablePrefix;
     }
 
     public Keyspace getKeyspace() {
         return keyspace;
+    }
+
+    public String getExecutionProfile() {
+        return this.executionProfile;
     }
 
     public boolean isValid() {
@@ -42,8 +52,9 @@ public class MigrationConfiguration {
     @Override
     public String toString() {
         return "MigrationConfiguration {" +
-                " [OPTIONAL] tablePrefix='" + tablePrefix + '\'' +
-                ",[REQUIRED] keyspace=" + keyspace +
+                " [REQUIRED] keyspace=" + keyspace +
+                ",[OPTIONAL] tablePrefix='" + tablePrefix + '\'' +
+                ",[OPTIONAL] executionProfile='" + executionProfile + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
Use the execution profile name and consistency level configured when
creating tables. This is necessary as some instances will fail with a
timeout on the table creations. Adding the execution profile allows the
table creation execution to be configurable.