### PR TITLE
Allow script-location property to be a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ the migration. You have to include the following dependency to make it work:
   </dependency>
 ```
 
-In your properties file you will have new properties that can be set:
+In your properties file you can set the following properties:
 * cassandra.migration.keyspace-name Specifies the keyspace that should be migrated
 * cassandra.migration.script-locations Overrides the default script location
 * cassandra.migration.strategy Can either be IGNORE_DUPLICATES or FAIL_ON_DUPLICATES

--- a/cassandra-migration-spring-boot-starter/pom.xml
+++ b/cassandra-migration-spring-boot-starter/pom.xml
@@ -20,7 +20,7 @@
     </description>
 
     <properties>
-        <spring.boot.version>2.6.1</spring.boot.version>
+        <spring.boot.version>2.6.5</spring.boot.version>
     </properties>
 
     <dependencies>
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>4.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -40,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -59,21 +58,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>5.3.13</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>${spring.boot.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>4.1.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -85,6 +72,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <version>${spring.boot.version}</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.nosan</groupId>
+            <artifactId>embedded-cassandra</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfiguration.java
@@ -36,7 +36,6 @@ public class CassandraMigrationAutoConfiguration {
         this.properties = properties;
     }
 
-
     @Bean(initMethod = "migrate")
     @ConditionalOnBean(value = CqlSession.class)
     @ConditionalOnMissingBean(MigrationTask.class)
@@ -61,8 +60,8 @@ public class CassandraMigrationAutoConfiguration {
         ScannerRegistry registry = new ScannerRegistry();
         registry.register(ScannerRegistry.JAR_SCHEME, new SpringBootLocationScanner());
         if (properties.getStrategy() == ScriptCollectorStrategy.FAIL_ON_DUPLICATES) {
-            return new MigrationRepository(properties.getScriptLocation(), new FailOnDuplicatesCollector(), registry);
+            return new MigrationRepository(properties.getScriptLocations(), new FailOnDuplicatesCollector(), registry);
         }
-        return new MigrationRepository(properties.getScriptLocation(), new IgnoreDuplicatesCollector(), registry);
+        return new MigrationRepository(properties.getScriptLocations(), new IgnoreDuplicatesCollector(), registry);
     }
 }

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -29,8 +29,7 @@ public class CassandraMigrationConfigurationProperties {
      * The location where the scripts reside on the classpath.
      * The default is <code>MigrationRepository.DEFAULT_SCRIPT_PATH</code> which
      * points to <code>cassandra/migration</code> on the classpath.
-     * @deprecated
-     * Use {@link #setScriptLocations(List)} instead.
+     * @deprecated Use {@link #setScriptLocations(List)} instead.
      *
      * @param scriptLocation the location of the migration scripts. Must not be null.
      * @throws IllegalArgumentException when scriptLocation is null or empty

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -26,6 +26,24 @@ public class CassandraMigrationConfigurationProperties {
     private Boolean withConsensus = false;
 
     /**
+     * The location where the scripts reside on the classpath.
+     * The default is <code>MigrationRepository.DEFAULT_SCRIPT_PATH</code> which
+     * points to <code>cassandra/migration</code> on the classpath.
+     * @deprecated
+     * Use {@link #setScriptLocations(List)} instead.
+     *
+     * @param scriptLocation the location of the migration scripts. Must not be null.
+     * @throws IllegalArgumentException when scriptLocation is null or empty
+     */
+    @Deprecated
+    public void setScriptLocation(String scriptLocation) {
+        if (scriptLocation == null || scriptLocation.isEmpty()) {
+            throw new IllegalArgumentException("Script location cannot be unset.");
+        }
+        this.scriptLocations = Collections.singletonList(scriptLocation);
+    }
+
+    /**
      * @return The locations of the migration scripts. Never null.
      */
     public List<String> getScriptLocations() {

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -3,6 +3,10 @@ package org.cognitor.cassandra.migration.spring;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import org.cognitor.cassandra.migration.MigrationRepository;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Configuration properties for the cassandra migration library.
@@ -14,7 +18,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "cassandra.migration")
 public class CassandraMigrationConfigurationProperties {
     private ScriptCollectorStrategy strategy = ScriptCollectorStrategy.FAIL_ON_DUPLICATES;
-    private String scriptLocation = MigrationRepository.DEFAULT_SCRIPT_PATH;
+    private List<String> scriptLocations = Collections.singletonList(MigrationRepository.DEFAULT_SCRIPT_PATH);
     private String keyspaceName;
     private String tablePrefix = "";
     private String executionProfileName = null;
@@ -22,10 +26,10 @@ public class CassandraMigrationConfigurationProperties {
     private Boolean withConsensus = false;
 
     /**
-     * @return The location of the migration scripts. Never null.
+     * @return The locations of the migration scripts. Never null.
      */
-    public String getScriptLocation() {
-        return scriptLocation;
+    public List<String> getScriptLocations() {
+        return scriptLocations;
     }
 
     /**
@@ -33,14 +37,14 @@ public class CassandraMigrationConfigurationProperties {
      * The default is <code>MigrationRepository.DEFAULT_SCRIPT_PATH</code> which
      * points to <code>cassandra/migration</code> on the classpath.
      *
-     * @param scriptLocation the location of the migration scripts. Must not be null.
+     * @param scriptLocations the locations of the migration scripts. Must not be null nor empty.
      * @throws IllegalArgumentException when scriptLocation is null or empty
      */
-    public void setScriptLocation(String scriptLocation) {
-        if (scriptLocation == null || scriptLocation.isEmpty()) {
-            throw new IllegalArgumentException("Script location cannot be unset.");
+    public void setScriptLocations(List<String> scriptLocations) {
+        if (CollectionUtils.isEmpty(scriptLocations)) {
+            throw new IllegalArgumentException("Script locations cannot be unset.");
         }
-        this.scriptLocation = scriptLocation;
+        this.scriptLocations = scriptLocations;
     }
 
     /**

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationProperties.java
@@ -46,7 +46,7 @@ public class CassandraMigrationConfigurationProperties {
      * @return The locations of the migration scripts. Never null.
      */
     public List<String> getScriptLocations() {
-        return scriptLocations;
+        return Collections.unmodifiableList(scriptLocations);
     }
 
     /**

--- a/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/scanner/SpringBootLocationScanner.java
+++ b/cassandra-migration-spring-boot-starter/src/main/java/org/cognitor/cassandra/migration/spring/scanner/SpringBootLocationScanner.java
@@ -28,15 +28,16 @@ import java.util.Set;
  * <a href="https://github.com/backjo">backjo</a>. Thanks a lot :)
  */
 public class SpringBootLocationScanner implements LocationScanner {
-    private PathMatchingResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+    private final PathMatchingResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
 
-        @Override
-        public Set<String> findResourceNames(String location, URI locationUri) throws IOException {
-            Resource[] resources = resourcePatternResolver.getResources(location + "*.cql");
+    @Override
+    public Set<String> findResourceNames(String location, URI locationUri) throws IOException {
+        Resource[] resources = resourcePatternResolver.getResources(location + "*.cql");
 
-            Set<String> resourcePaths = new HashSet<>();
-            for (Resource resource : resources) {
-                resourcePaths.add(location + resource.getFilename());
-            }
-            return resourcePaths;
-        }}
+        Set<String> resourcePaths = new HashSet<>();
+        for (Resource resource : resources) {
+            resourcePaths.add(location + resource.getFilename());
+        }
+        return resourcePaths;
+    }
+}

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
@@ -10,8 +10,6 @@ import com.github.nosan.embedded.cassandra.CassandraBuilder;
 import org.cognitor.cassandra.migration.MigrationTask;
 import org.hamcrest.CoreMatchers;
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -33,7 +31,6 @@ public class CassandraMigrationAutoConfigurationTest {
     private static final String KEYSPACE = "test_keyspace";
 
     private static Cassandra cassandra;
-    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraMigrationAutoConfigurationTest.class);
 
     @BeforeClass
     public static void initDb() {
@@ -41,7 +38,6 @@ public class CassandraMigrationAutoConfigurationTest {
                 .version("3.11.12")
                 .build();
         cassandra.start();
-        LOGGER.warn("cassandra started successfully");
     }
 
     @AfterClass
@@ -49,7 +45,6 @@ public class CassandraMigrationAutoConfigurationTest {
         if (null != cassandra) {
             cassandra.stop();
         }
-        LOGGER.warn("cassandra stopped successfully");
     }
 
     @Before

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationAutoConfigurationTest.java
@@ -93,7 +93,7 @@ public class CassandraMigrationAutoConfigurationTest {
         AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext();
         TestPropertyValues testValues = TestPropertyValues.of("cassandra.migration.keyspace-name:" + KEYSPACE,
-                "cassandra.migration.script-locations:cassandra/common,cassandra/dev");
+                "cassandra.migration.script-locations:cassandra/dev,cassandra/common");
         testValues.applyTo(context);
         context.register(ClusterConfig.class, CassandraMigrationAutoConfiguration.class);
         context.refresh();

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,7 +22,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext();
         TestPropertyValues testValues = TestPropertyValues.of(
-                "cassandra.migration.script-location:cassandra/migrationpath",
+                "cassandra.migration.script-locations:cassandra/migrationpath,cassandra/other",
                 "cassandra.migration.keyspace-name:test_keyspace",
                 "cassandra.migration.strategy:IGNORE_DUPLICATES",
                 "cassandra.migration.consistency-level:all",
@@ -32,12 +35,31 @@ public class CassandraMigrationConfigurationPropertiesTest {
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
         assertThat(properties.getKeyspaceName(), is(equalTo("test_keyspace")));
-        assertThat(properties.getScriptLocation(), is(equalTo("cassandra/migrationpath")));
+        assertThat(properties.getScriptLocations(), is(equalTo(Arrays.asList("cassandra/migrationpath", "cassandra/other"))));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.IGNORE_DUPLICATES)));
         assertThat(properties.getConsistencyLevel(), is(equalTo(DefaultConsistencyLevel.ALL)));
         assertThat(properties.getTablePrefix(), is(equalTo("prefix")));
         assertThat(properties.isWithConsensus(), is(true));
         assertThat(properties.getExecutionProfileName(), is(equalTo("testProfile")));
+    }
+
+    @Test
+    public void shouldPopulatePropertiesWhenPropertiesFileGivenMultipleLocations() {
+        AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext();
+        TestPropertyValues testValues = TestPropertyValues.of(
+                "cassandra.migration.script-locations:cassandra/migrationpath");
+        testValues.applyTo(context);
+        context.register(CassandraMigrationAutoConfiguration.class);
+        context.refresh();
+        CassandraMigrationConfigurationProperties properties =
+                context.getBean(CassandraMigrationConfigurationProperties.class);
+        assertThat(properties.hasKeyspaceName(), is(false));
+        assertThat(properties.getScriptLocations(), is(equalTo(Collections.singletonList("cassandra/migrationpath"))));
+        assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
+        assertThat(properties.getTablePrefix(), is(equalTo("")));
+        assertThat(properties.isWithConsensus(), is(false));
+        assertThat(properties.getExecutionProfileName(), is(nullValue()));
     }
 
     @Test
@@ -49,7 +71,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
         assertThat(properties.hasKeyspaceName(), is(false));
-        assertThat(properties.getScriptLocation(), is(equalTo("cassandra/migration")));
+        assertThat(properties.getScriptLocations(), is(equalTo(Collections.singletonList("cassandra/migration"))));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
         assertThat(properties.getTablePrefix(), is(equalTo("")));
         assertThat(properties.isWithConsensus(), is(false));

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -22,7 +22,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext();
         TestPropertyValues testValues = TestPropertyValues.of(
-                "cassandra.migration.script-locations:cassandra/migrationpath,cassandra/other",
+                "cassandra.migration.script-location:cassandra/migrationpath",
                 "cassandra.migration.keyspace-name:test_keyspace",
                 "cassandra.migration.strategy:IGNORE_DUPLICATES",
                 "cassandra.migration.consistency-level:all",
@@ -35,7 +35,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
         assertThat(properties.getKeyspaceName(), is(equalTo("test_keyspace")));
-        assertThat(properties.getScriptLocations(), is(equalTo(Arrays.asList("cassandra/migrationpath", "cassandra/other"))));
+        assertThat(properties.getScriptLocations(), is(equalTo(Collections.singletonList("cassandra/migrationpath"))));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.IGNORE_DUPLICATES)));
         assertThat(properties.getConsistencyLevel(), is(equalTo(DefaultConsistencyLevel.ALL)));
         assertThat(properties.getTablePrefix(), is(equalTo("prefix")));
@@ -48,14 +48,14 @@ public class CassandraMigrationConfigurationPropertiesTest {
         AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext();
         TestPropertyValues testValues = TestPropertyValues.of(
-                "cassandra.migration.script-locations:cassandra/migrationpath");
+                "cassandra.migration.script-locations:cassandra/migrationpath,cassandra/other");
         testValues.applyTo(context);
         context.register(CassandraMigrationAutoConfiguration.class);
         context.refresh();
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
         assertThat(properties.hasKeyspaceName(), is(false));
-        assertThat(properties.getScriptLocations(), is(equalTo(Collections.singletonList("cassandra/migrationpath"))));
+        assertThat(properties.getScriptLocations(), is(equalTo(Arrays.asList("cassandra/migrationpath", "cassandra/other"))));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
         assertThat(properties.getTablePrefix(), is(equalTo("")));
         assertThat(properties.isWithConsensus(), is(false));

--- a/cassandra-migration-spring-boot-starter/src/test/resources/application.properties
+++ b/cassandra-migration-spring-boot-starter/src/test/resources/application.properties
@@ -1,4 +1,0 @@
-cassandra.migration.keyspace-name=test_keyspace
-cassandra.migration.script-location=cassandra/migrationpath
-cassandra.migration.strategy=IGNORE_DUPLICATES
-cassandra.migration.consistency-level=all

--- a/cassandra-migration-spring-boot-starter/src/test/resources/cassandra/common/001_create_person_table.cql
+++ b/cassandra-migration-spring-boot-starter/src/test/resources/cassandra/common/001_create_person_table.cql
@@ -1,0 +1,1 @@
+CREATE TABLE PERSON (id uuid primary key, name varchar);

--- a/cassandra-migration-spring-boot-starter/src/test/resources/cassandra/dev/100_populate_person_table.cql
+++ b/cassandra-migration-spring-boot-starter/src/test/resources/cassandra/dev/100_populate_person_table.cql
@@ -1,0 +1,1 @@
+INSERT INTO PERSON (id, name) VALUES (uuid(), 'test');

--- a/cassandra-migration/pom.xml
+++ b/cassandra-migration/pom.xml
@@ -30,7 +30,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -45,6 +45,11 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.nosan</groupId>
+            <artifactId>embedded-cassandra</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationRepository.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/MigrationRepository.java
@@ -17,7 +17,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,7 +105,20 @@ public class MigrationRepository {
      *                            the repository contains duplicate script versions
      */
     public MigrationRepository(String scriptPath) {
-        this(scriptPath, new FailOnDuplicatesCollector());
+        this(Collections.singletonList(scriptPath), new FailOnDuplicatesCollector());
+    }
+
+    /**
+     * Creates a new repository with the given scriptPaths and the default
+     * {@link ScriptCollector} that will throw an exception in case
+     * there are duplicate versions inside the repository.
+     *
+     * @param scriptPaths paths on the classpath to the migration scripts. Must not be null.
+     * @throws MigrationException in case there is a problem reading the scripts in the path or
+     *                            the repository contains duplicate script versions
+     */
+    public MigrationRepository(List<String> scriptPaths) {
+        this(scriptPaths, new FailOnDuplicatesCollector());
     }
 
     /**
@@ -115,7 +130,19 @@ public class MigrationRepository {
      * @throws MigrationException in case there is a problem reading the scripts in the path.
      */
     public MigrationRepository(String scriptPath, ScriptCollector scriptCollector) {
-        this(scriptPath, scriptCollector, new ScannerRegistry());
+        this(Collections.singletonList(scriptPath), scriptCollector, new ScannerRegistry());
+    }
+
+    /**
+     * Creates a new repository with the given scriptPaths and the given
+     * {@link ScriptCollector}.
+     *
+     * @param scriptPaths paths on the classpath to the migration scripts. Must not be null.
+     * @param scriptCollector the collection strategy used to collect the scripts. Must not be null.
+     * @throws MigrationException in case there is a problem reading the scripts in the path.
+     */
+    public MigrationRepository(List<String> scriptPaths, ScriptCollector scriptCollector) {
+        this(scriptPaths, scriptCollector, new ScannerRegistry());
     }
 
     /**
@@ -128,11 +155,36 @@ public class MigrationRepository {
      * @throws MigrationException in case there is a problem reading the scripts in the path.
      */
     public MigrationRepository(String scriptPath, ScriptCollector scriptCollector, ScannerRegistry scannerRegistry) {
+        this(Collections.singletonList(scriptPath), scriptCollector, scannerRegistry);
+    }
+
+    /**
+     * Creates a new repository with the given scriptPaths and the given
+     * {@link ScriptCollector}.
+     *
+     * @param scriptPaths the paths on the classpath to the migration scripts. Must not be null.
+     * @param scriptCollector the collection strategy used to collect the scripts. Must not be null.
+     * @param scannerRegistry A ScannerRegistry to create LocationScanner instances. Must not be null.
+     * @throws MigrationException in case there is a problem reading the scripts in the path.
+     */
+    public MigrationRepository(List<String> scriptPaths, ScriptCollector scriptCollector, ScannerRegistry scannerRegistry) {
+        if (null == scriptPaths || scriptPaths.isEmpty()) {
+            throw new IllegalArgumentException("Argument scriptPaths must not be null or empty.");
+        }
+
         this.scriptCollector = notNull(scriptCollector, "scriptCollector");
         this.scannerRegistry = notNull(scannerRegistry, "scannerRegistry");
         this.commentPattern = compile(SINGLE_LINE_COMMENT_PATTERN);
         try {
-            migrationScripts = scanForScripts(normalizePath(notNullOrEmpty(scriptPath, "scriptPath")));
+            for (String scriptPath : scriptPaths) {
+                scanAndCollectScripts(normalizePath(notNullOrEmpty(scriptPath, "scriptPath")));
+            }
+
+            List<ScriptFile> scripts = new ArrayList<>(scriptCollector.getScriptFiles());
+            LOGGER.info(format("Found %d migration scripts", scripts.size()));
+
+            sort(scripts);
+            migrationScripts = scripts;
         } catch (IOException | URISyntaxException exception) {
             throw new MigrationException(SCANNING_SCRIPT_FOLDER_ERROR_MSG, exception);
         }
@@ -175,12 +227,12 @@ public class MigrationRepository {
         return migrationScripts.get(migrationScripts.size() - 1).getVersion();
     }
 
-    private List<ScriptFile> scanForScripts(String scriptPath) throws IOException, URISyntaxException {
+    private void scanAndCollectScripts(String scriptPath) throws IOException, URISyntaxException {
         LOGGER.debug("Scanning for cql migration scripts in " + scriptPath);
         Enumeration<URL> scriptResources = getClass().getClassLoader().getResources(scriptPath);
         while (scriptResources.hasMoreElements()) {
             URI script = scriptResources.nextElement().toURI();
-            LOGGER.debug("Potential script folder: {}", script.toString());
+            LOGGER.debug("Potential script folder: {}", script);
             if (!scannerRegistry.supports(script.getScheme())) {
                 LOGGER.debug("No LocationScanner available for scheme '{}'. Skipping it.", script.getScheme());
                 continue;
@@ -196,10 +248,6 @@ public class MigrationRepository {
                 }
             }
         }
-        List<ScriptFile> scripts = new ArrayList<>(scriptCollector.getScriptFiles());
-        LOGGER.info(format("Found %d migration scripts", scripts.size()));
-        sort(scripts);
-        return scripts;
     }
 
     private static int extractScriptVersion(String scriptName) {
@@ -261,7 +309,7 @@ public class MigrationRepository {
 
     private String readResourceFileAsString(String resourceName, ClassLoader classLoader) throws IOException {
         return new BufferedReader(new InputStreamReader(
-                classLoader.getResourceAsStream(resourceName),
+                Objects.requireNonNull(classLoader.getResourceAsStream(resourceName)),
                 SCRIPT_ENCODING
         )).lines()
                 .filter(line -> !isLineComment(line))

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/scanner/JarLocationScanner.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/scanner/JarLocationScanner.java
@@ -43,7 +43,7 @@ public class JarLocationScanner implements LocationScanner {
             LOGGER.debug("Trying to get existing filesystem for {}", location.toString());
             return FileSystems.getFileSystem(location);
         } catch (FileSystemNotFoundException exception) {
-            LOGGER.debug("Creating new filesystem for {}", location.toString());
+            LOGGER.debug("Creating new filesystem for {}", location);
             return FileSystems.newFileSystem(location, emptyMap());
         }
     }

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
@@ -20,8 +20,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -49,7 +47,6 @@ public class DatabaseTest {
     private static final int REQUEST_TIMEOUT_IN_SECONDS = 30;
     private CqlSession session;
     private static Cassandra cassandra;
-    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseTest.class);
 
     @BeforeClass
     public static void initDb() {
@@ -58,7 +55,6 @@ public class DatabaseTest {
                 .addConfigProperty("enable_user_defined_functions", true)
                 .build();
         cassandra.start();
-        LOGGER.warn("cassandra started successfully");
     }
 
     @AfterClass
@@ -66,7 +62,6 @@ public class DatabaseTest {
         if (null != cassandra) {
             cassandra.stop();
         }
-        LOGGER.warn("cassandra stopped successfully");
     }
 
     @Before

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/it/migration/DatabaseTest.java
@@ -7,6 +7,8 @@ import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.github.nosan.embedded.cassandra.Cassandra;
+import com.github.nosan.embedded.cassandra.CassandraBuilder;
 import org.cognitor.cassandra.migration.Database;
 import org.cognitor.cassandra.migration.MigrationException;
 import org.cognitor.cassandra.migration.MigrationRepository;
@@ -14,8 +16,12 @@ import org.cognitor.cassandra.migration.MigrationTask;
 import org.cognitor.cassandra.migration.keyspace.Keyspace;
 import org.cognitor.cassandra.migration.keyspace.NetworkStrategy;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
@@ -39,8 +45,29 @@ public class DatabaseTest {
     private static final String NETWORK_KEYSPACE = "network_keyspace";
     private static final String NEW_KEYSPACE = "new_keyspace";
     private static final String CASSANDRA_HOST = "127.0.0.1";
+    private static final int CASSANDRA_PORT = 9042;
     private static final int REQUEST_TIMEOUT_IN_SECONDS = 30;
     private CqlSession session;
+    private static Cassandra cassandra;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseTest.class);
+
+    @BeforeClass
+    public static void initDb() {
+        cassandra = new CassandraBuilder()
+                .version("3.11.12")
+                .addConfigProperty("enable_user_defined_functions", true)
+                .build();
+        cassandra.start();
+        LOGGER.warn("cassandra started successfully");
+    }
+
+    @AfterClass
+    public static void stopDb() {
+        if (null != cassandra) {
+            cassandra.stop();
+        }
+        LOGGER.warn("cassandra stopped successfully");
+    }
 
     @Before
     public void before() {
@@ -67,7 +94,7 @@ public class DatabaseTest {
                 .withBoolean(DefaultDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, false)
                 .build();
         return new CqlSessionBuilder()
-                .addContactPoint(new InetSocketAddress(CASSANDRA_HOST, 9042))
+                .addContactPoint(new InetSocketAddress(CASSANDRA_HOST, CASSANDRA_PORT))
                 .withConfigLoader(loader)
                 .withLocalDatacenter("datacenter1")
                 .build();
@@ -148,7 +175,7 @@ public class DatabaseTest {
                             new MigrationRepository("cassandra/migrationtest/successful"),
                             true));
         }
-        List<Callable<Boolean>> migrations = migrationTasks.stream().map(task -> databaseMigrationTask(task))
+        List<Callable<Boolean>> migrations = migrationTasks.stream().map(this::databaseMigrationTask)
                 .collect(Collectors.toList());
 
         // Executing the same migration concurrently with different threads

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/scanner/JarLocationScannerTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/scanner/JarLocationScannerTest.java
@@ -1,6 +1,8 @@
 package org.cognitor.cassandra.migration.scanner;
 
 import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -15,6 +17,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
+import static io.netty.util.internal.PlatformDependent.isWindows;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
@@ -27,6 +30,11 @@ public class JarLocationScannerTest {
 
     private static File jarFile;
     private static URI jarUri;
+
+    @Before
+    public void windowsOnly() {
+        Assume.assumeFalse(isWindows());
+    }
 
     @BeforeClass
     public static void beforeClass() throws IOException, URISyntaxException {

--- a/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/scanner/JarLocationScannerTest.java
+++ b/cassandra-migration/src/test/java/org/cognitor/cassandra/migration/scanner/JarLocationScannerTest.java
@@ -33,7 +33,7 @@ public class JarLocationScannerTest {
 
     @Before
     public void windowsOnly() {
-        Assume.assumeFalse(isWindows());
+        Assume.assumeFalse("Disable tests on Windows", isWindows());
     }
 
     @BeforeClass

--- a/pom.xml
+++ b/pom.xml
@@ -73,12 +73,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.32</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.32</version>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.36</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -91,6 +91,12 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.nosan</groupId>
+                <artifactId>embedded-cassandra</artifactId>
+                <version>4.0.6</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Similar to Flyway, we can have the possibility to set multiple location for script paths (https://flywaydb.org/documentation/configuration/parameters/locations)

Job done :
- set locations to a List
- keep and deprecate `script-location` in spring properties for backward compatibility
- keep `scriptPath` as a String for backward compatibility in the `MigrationRepository` class
- disable JarLocationScannerTest on Windows as it fails (need investigation on that one), cf #57 
- update dependencies (spring-boot, slf4j & cassandra driver)
- execute tests with embedded-cassandra : no need for a running cassandra instance, this library runs it for us (similar to cassandra-unit)

We can choose which cassandra-unit version to use for tests, just one note is that cassandra itself has drop support for windows since early 4.0 beta, so if we want to enable testing cassandra 4+ on all environment, the only solution will be to use Testcontainers