### PR TITLE
Spring improvements

### DIFF
--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -5,8 +5,6 @@ import org.cognitor.cassandra.migration.keyspace.NetworkStrategy;
 import org.cognitor.cassandra.migration.keyspace.ReplicationStrategy;
 import org.cognitor.cassandra.migration.keyspace.SimpleStrategy;
 import org.junit.Test;
-import org.springframework.beans.BeanInstantiationException;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.NestedExceptionUtils;

--- a/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
+++ b/cassandra-migration-spring-boot-starter/src/test/java/org/cognitor/cassandra/migration/spring/CassandraMigrationConfigurationPropertiesTest.java
@@ -58,6 +58,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         context.refresh();
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
+        assertThat(properties.hasKeyspaceName(), is(true));
         assertThat(properties.getKeyspaceName(), is(equalTo("test_keyspace")));
         ReplicationStrategy replicationStrategy = properties.getReplicationStrategy();
         assertThat(replicationStrategy, is(instanceOf(NetworkStrategy.class)));
@@ -91,6 +92,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         context.refresh();
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
+        assertThat(properties.hasKeyspaceName(), is(true));
         assertThat(properties.getKeyspaceName(), is(equalTo("test_keyspace")));
         ReplicationStrategy replicationStrategy = properties.getReplicationStrategy();
         assertThat(replicationStrategy, is(instanceOf(SimpleStrategy.class)));
@@ -115,6 +117,7 @@ public class CassandraMigrationConfigurationPropertiesTest {
         context.refresh();
         CassandraMigrationConfigurationProperties properties =
                 context.getBean(CassandraMigrationConfigurationProperties.class);
+        assertThat(properties.hasKeyspaceName(), is(true));
         assertThat(properties.getScriptLocations(), is(equalTo(Arrays.asList("cassandra/migrationpath", "cassandra/other"))));
         assertThat(properties.getStrategy(), is(equalTo(ScriptCollectorStrategy.FAIL_ON_DUPLICATES)));
         assertThat(properties.getTablePrefix(), is(equalTo("")));

--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/keyspace/Keyspace.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/keyspace/Keyspace.java
@@ -64,6 +64,6 @@ public class Keyspace {
                 " WITH REPLICATION = " +
                 getReplicationStrategy().createCqlStatement() +
                 " AND DURABLE_WRITES = " +
-                Boolean.toString(isDurableWrites());
+                isDurableWrites();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>com.datastax.oss</groupId>
                 <artifactId>java-driver-core</artifactId>
-                <version>4.13.0</version>
+                <version>4.14.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>com.github.nosan</groupId>
                 <artifactId>embedded-cassandra</artifactId>
-                <version>4.0.6</version>
+                <version>4.0.7</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
With current version, spring users have to redefine the whole `MigrationTask` in case for example they want to implement a custom `LocationScanner`
Users should be able to override the minimum necessary beans if needed and not the whole feature

I also increased the driver to the latest version (I thought I did with another PR but it seems I forgot it)