### PR TITLE
Remove usage of dateOf which is removed in Cassandra 5.0

### DIFF
--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
@@ -63,7 +63,7 @@ public class Database implements Closeable {
      * The query that attempts to get the lead on schema migrations
      */
     private static final String TAKE_LEAD_QUERY =
-            "INSERT INTO %s (keyspace_name, leader, took_lead_at, leader_hostname) VALUES (?, ?, dateOf(now()), ?) IF NOT EXISTS USING TTL %s";
+            "INSERT INTO %s (keyspace_name, leader, took_lead_at, leader_hostname) VALUES (?, ?, toTimestamp(now()), ?) IF NOT EXISTS USING TTL %s";
 
     /**
      * The query that releases the lead on schema migrations


### PR DESCRIPTION
The deprecated `dateOf()` function was removed in trunk and will be absent in Cassandra 5.0.
We need to replace it with `toTimestamp()` which provides similar functionality.

Sadly I don't see how we can test this in tests since cassandra-unit doesn't support using recent versions of Cassandra, let alone trunk AFAIK.