### PR TITLE
Issue #83: Switch to toTimestamp instead of dateOf in order to support Cassandra 5x

### DIFF
--- a/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
+++ b/cassandra-migration/src/main/java/org/cognitor/cassandra/migration/Database.java
@@ -63,7 +63,7 @@ public class Database implements Closeable {
      * The query that attempts to get the lead on schema migrations
      */
     private static final String TAKE_LEAD_QUERY =
-            "INSERT INTO %s (keyspace_name, leader, took_lead_at, leader_hostname) VALUES (?, ?, dateOf(now()), ?) IF NOT EXISTS USING TTL %s";
+            "INSERT INTO %s (keyspace_name, leader, took_lead_at, leader_hostname) VALUES (?, ?, toTimestamp(now()), ?) IF NOT EXISTS USING TTL %s";
 
     /**
      * The query that releases the lead on schema migrations


### PR DESCRIPTION
To address https://issues.apache.org/jira/browse/CASSANDRA-18328 removal of the deprecated cql function dateOf