### PR TITLE
Add support for setting the serial consistency level for leader election

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Maven CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run Maven tests
+        run: mvn --batch-mode test
+

--- a/cassandra-migration-spring-boot-starter/pom.xml
+++ b/cassandra-migration-spring-boot-starter/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.cognitor.cassandra</groupId>
         <artifactId>cassandra-migration-parent</artifactId>
-        <version>2.6.2_v4-SNAPSHOT</version>
+        <version>2.6.3_v4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-migration-spring-boot-starter</artifactId>
-    <version>2.6.2_v4-SNAPSHOT</version>
+    <version>2.6.3_v4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Cassandra Migration Spring Boot Integration</name>
     <url>https://github.com/patka/cassandra-migration</url>

--- a/cassandra-migration/pom.xml
+++ b/cassandra-migration/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.cognitor.cassandra</groupId>
         <artifactId>cassandra-migration-parent</artifactId>
-        <version>2.6.2_v4-SNAPSHOT</version>
+        <version>2.6.3_v4-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-migration</artifactId>
-    <version>2.6.2_v4-SNAPSHOT</version>
+    <version>2.6.3_v4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Cassandra Migration</name>
     <url>https://github.com/patka/cassandra-migration</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.cognitor.cassandra</groupId>
     <artifactId>cassandra-migration-parent</artifactId>
-    <version>2.6.2_v4-SNAPSHOT</version>
+    <version>2.6.3_v4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cassandra Migration Parent</name>
     <url>https://github.com/patka/cassandra-migration</url>


### PR DESCRIPTION
Defaulting to SERIAL, the LWTs used for leader election now have the consistency levels configurable, and are no longer using QUORUM, since that doesn't make sense for LWTs anyway. I don't know what C* does when you pass a LWT using QUORUM, it probably defaults to SERIAL.

This should fix #45 